### PR TITLE
Embed resources in qmd-generated html files

### DIFF
--- a/pipeline/L0.qmd
+++ b/pipeline/L0.qmd
@@ -14,6 +14,7 @@ date: now
 date-format: "YYYY-MM-DD HH:mm:ssZ"
 format: 
   html:
+    embed-resources: true
     code-fold: true
 editor: visual
 ---

--- a/pipeline/L1.qmd
+++ b/pipeline/L1.qmd
@@ -20,6 +20,7 @@ date: now
 date-format: "YYYY-MM-DD HH:mm:ssZ"
 format: 
   html:
+    embed-resources: true
     code-fold: true
 editor: visual
 ---
@@ -303,3 +304,4 @@ Git commit `r GIT_COMMIT`.
 ```{r reproducibility}
 sessionInfo()
 ```
+

--- a/pipeline/L1_normalize.qmd
+++ b/pipeline/L1_normalize.qmd
@@ -17,6 +17,7 @@ date: now
 date-format: "YYYY-MM-DD HH:mm:ssZ"
 format: 
   html:
+    embed-resources: true
     code-fold: true
 editor: visual
 ---
@@ -318,3 +319,4 @@ Git commit `r GIT_COMMIT`.
 ```{r reproducibility}
 sessionInfo()
 ```
+

--- a/pipeline/L2.qmd
+++ b/pipeline/L2.qmd
@@ -15,6 +15,7 @@ date: now
 date-format: "YYYY-MM-DD HH:mm:ssZ"
 format: 
   html:
+    embed-resources: true
     code-fold: true
 editor: visual
 ---
@@ -155,3 +156,4 @@ Git commit `r GIT_COMMIT`.
 ```{r reproducibility}
 sessionInfo()
 ```
+


### PR DESCRIPTION
Right now, each Quarto file generated an `html` file and accompanying folder of "resources" (style information, graphics, etc). This means that if we move the html  elsewhere, e.g. archive it on the HPC, things turn ugly:

<img width="700" alt="Screenshot 2025-02-24 at 9 59 30 AM" src="https://github.com/user-attachments/assets/6558e103-34a1-4567-9e76-db3a82b54408" />

This PR embeds all resources _within_ the html files, making for nicer-looking logs:

<img width="909" alt="Screenshot 2025-02-24 at 9 59 52 AM" src="https://github.com/user-attachments/assets/ed7c3000-a23e-4254-aafa-0a2b073e6bb7" />
