### PR TITLE
Bounds value fixes for VP and BP

### DIFF
--- a/pipeline/metadata/L1_metadata/L1_metadata_variables.csv
+++ b/pipeline/metadata/L1_metadata/L1_metadata_variables.csv
@@ -52,11 +52,11 @@ ClimaVue50_15min,AirT_C_Max,wx_tempmax15,degC,degC,x * 1,-50,60,Maximum air temp
 ClimaVue50_15min,AirT_C_TMx,wx_temptmx15,,,x * 1,,,Time of maximum air temperature in 15 minute period
 ClimaVue50_15min,AirT_C_Min,wx_tempmin15,degC,degC,x * 1,-50,60,Minimum air temperature in 15 minute period
 ClimaVue50_15min,AirT_C_TMn,wx_temptmn15,,,x * 1,,,Time of minimum air temperature in 15 minute period
-ClimaVue50_15min,VP_mbar_Avg,wx_vappress15,mbar,mbar,x * 1,500,1100,Average vapor pressure over 15 minute period
-ClimaVue50_15min,BP_mbar,wx_barpress15,mbar,mbar,x * 1,500,1100,Barometric pressure
-ClimaVue50_15min,BP_mbar_Max,wx_bpmax15,mbar,mbar,x * 1,500,1100,Maximum barometric pressure in 15 minute period
+ClimaVue50_15min,VP_mbar_Avg,wx_vappress15,mbar,mbar,x * 1,0,470,Average vapor pressure over 15 minute period
+ClimaVue50_15min,BP_mbar,wx_barpress15,mbar,mbar,x * 1,50000,110000,Barometric pressure
+ClimaVue50_15min,BP_mbar_Max,wx_bpmax15,mbar,mbar,x * 1,50000,110000,Maximum barometric pressure in 15 minute period
 ClimaVue50_15min,BP_mbar_TMx,wx_bptmx15,,,x * 1,,,Time of maximum barometric pressure in 15 minute period
-ClimaVue50_15min,BP_mbar_Min,wx_bpmin15,mbar,mbar,x * 1,500,1100,Minimum barometric pressure in 15 minute period
+ClimaVue50_15min,BP_mbar_Min,wx_bpmin15,mbar,mbar,x * 1,50000,110000,Minimum barometric pressure in 15 minute period
 ClimaVue50_15min,BP_mbar_TMn,wx_bptmn15,,,x * 1,,,Time of minimum barometric pressure in 15 minute period
 ClimaVue50_15min,RH,wx_rh15,perc,perc,x * 1,0,100,Relative humidity
 ClimaVue50_15min,RHT_C_Avg,wx_rht15,degC,degC,x * 1,,,Average temperature of humidity sensor over 15 minute period

--- a/pipeline/metadata/L1_metadata/L1_metadata_variables.csv
+++ b/pipeline/metadata/L1_metadata/L1_metadata_variables.csv
@@ -76,16 +76,16 @@ ClimaVue50_24hr,WS_ms_WVc(2),,degrees,degrees,x * 1,0,359,Unit vector mean wind 
 ClimaVue50_24hr,WS_ms_S_WVT,wx_winderrors24,,,x * 1,0,,Sum of wind error code over 24 hr period (wind data is invalid if error >0)
 ClimaVue50_24hr,MaxWS_ms_Max,wx_maxws24,m/s,m/s,x * 1,0,30,Maximum wind speed (10s gust) over 24 hr period
 ClimaVue50_24hr,MaxWS_ms_TMx,wx_maxws_tmx24,,,x * 1,,,Time of maximum wind speed over 24 hr period
-ClimaVue50_24hr,AirT_C_Avg,wx_tempavg24,m/s,m/s,x * 1,0,30,Maximum wind speed (10s gust) over 24 hr period
-ClimaVue50_24hr,AirT_C_Max,wx_tempmax24,,,x * 1,,,Time of maximum wind speed over 24 hr period
-ClimaVue50_24hr,AirT_C_TMx,wx_temptmx24,degC,degC,x * 1,-50,60,Average air temperature over 24 hr period
-ClimaVue50_24hr,AirT_C_Min,wx_tempmin24,degC,degC,x * 1,-50,60,Maximum air temperature over 24 hr period
-ClimaVue50_24hr,AirT_C_TMn,wx_temptmn24,,,x * 1,,,Time of maximum air temperature over 24 hr period
-ClimaVue50_24hr,VP_mbar_Avg,wx_vappress24,degC,degC,x * 1,-50,60,Minimum air temperature over 24 hr period
-ClimaVue50_24hr,BP_mbar_Max,wx_bpmax24,,,x * 1,,,Time of minimum air temperature over 24 hr period
-ClimaVue50_24hr,BP_mbar_TMx,wx_bptmx24,mbar,mbar,x * 1,0,470,Mean vapor pressure over 24 hr period
-ClimaVue50_24hr,BP_mbar_Min,wx_bpmin24,mbar,mbar,x * 1,500,1100,Maximum barometric pressure over 24 hr period
-ClimaVue50_24hr,BP_mbar_TMn,wx_bptmn24,,,x * 1,,,Time of maximum barometric pressure over 24 hr period
+ClimaVue50_24hr,AirT_C_Avg,wx_tempavg24,degC,degC,x * 1,-50,60,Average air temperature over 24 hr period
+ClimaVue50_24hr,AirT_C_Max,wx_tempmax24,degC,degC,x * 1,-50,60,Maximum air temperature over 24 hr period
+ClimaVue50_24hr,AirT_C_TMx,wx_temptmx24,,,x * 1,,,Time of maximum air temperature over 24 hr period
+ClimaVue50_24hr,AirT_C_Min,wx_tempmin24,degC,degC,x * 1,-50,60,Minimum air temperature over 24 hr period
+ClimaVue50_24hr,AirT_C_TMn,wx_temptmn24,,,x * 1,,,Time of minimum air temperature over 24 hr period
+ClimaVue50_24hr,VP_mbar_Avg,wx_vappress24,mbar,mbar,x * 1,0,470,Mean vapor pressure over 24 hr period
+ClimaVue50_24hr,BP_mbar_Max,wx_bpmax24,mbar,mbar,x * 1,50000,110000,Maximum barometric pressure over 24 hr period
+ClimaVue50_24hr,BP_mbar_TMx,wx_bptmx24,,,x * 1,,,Time of maximum barometric pressure over 24 hr period
+ClimaVue50_24hr,BP_mbar_Min,wx_bpmin24,mbar,mbar,x * 1,50000,110000,Minimum barometric pressure over 24 hr period
+ClimaVue50_24hr,BP_mbar_TMn,wx_bptmn24,,,x * 1,,,Time of minimum barometric pressure over 24 hr period
 ClimaVue50_24hr,RH_Max,wx_rh24,perc,perc,x * 1,0,100,Maximum relative humidity over 24 hr period
 ClimaVue50_24hr,RH_Min,wx_rht24,perc,perc,x * 1,0,100,Minimum relative humidity over 24 hr period
 ClimaVue50_24hr,RHT_C_Max,wx_rhtmax24,degC,degC,x * 1,-50,60,Maximum temperature of humidity sensor over 24 hr period


### PR DESCRIPTION
ClimaVue [documentation](https://www.campbellsci.com/climavue-50):

<img width="554" alt="Screenshot 2025-04-05 at 07 34 35" src="https://github.com/user-attachments/assets/fa096218-0ade-4095-ba84-85d1324339ee" />

From this I think that VP bounds should be 0 to 470 mbar (=0 to 47 kPa) and BP bounds 50,000 to 110,000 mbar (=500 to 1100 hPa = 5000 to 11000 kPa).

<img width="915" alt="Screenshot 2025-04-05 at 07 31 55" src="https://github.com/user-attachments/assets/6a9ccfdb-2ccb-4132-9dd3-871c111bbbdd" />

@roylrich Please double-check

Addresses #283