### PR TITLE
Remove sensor units from metadata files

### DIFF
--- a/pipeline/L1.qmd
+++ b/pipeline/L1.qmd
@@ -197,7 +197,6 @@ col_md_for_insert <- paste(sprintf("%-15s", column_md$Column), column_md$Descrip
 # Get the variable metadata
 var_md <- read.csv(file.path(params$METADATA_ROOT, params$L1_METADATA, params$METADATA_VARS_TABLE))
 var_md_for_insert <- paste(sprintf("%-20s", c("research_name", var_md$research_name)),
-                           sprintf("%-12s", c("Sensor", var_md$sensor)),
                            sprintf("%-10s", c("Units", var_md$final_units)),
                            sprintf("%-12s", c("Bounds", paste0(var_md$low_bound, ", ", var_md$high_bound))),
                            c("Description", var_md$description))


### PR DESCRIPTION
This PR removes the sensor units from the site metadata files, which were confusing to have in there. Now we just report the final units:
<img width="563" alt="Screenshot 2025-05-09 at 16 39 53" src="https://github.com/user-attachments/assets/943f0909-4060-452c-a04b-d74e3d7a2475" />

Closes #304 