### PR TITLE
When completing data, fill N_avg and N_drop correctly

### DIFF
--- a/pipeline/L2_qaqc-utils.R
+++ b/pipeline/L2_qaqc-utils.R
@@ -54,7 +54,7 @@ L2_complete <- function(x) {
         complete(x,
                  TIMESTAMP = timespan,
                  nesting(Site, Plot, Instrument, Instrument_ID, Sensor_ID, Location, research_name),
-                 fill = list(Value = NA_real_, n = 0, n_drop = 0))
+                 fill = list(Value = NA_real_, N_avg = 0, N_drop = 0))
     })
     do.call("rbind", y)
 }

--- a/pipeline/L2_qaqc.qmd
+++ b/pipeline/L2_qaqc.qmd
@@ -183,7 +183,7 @@ f <- function(fn, out_dir) {
     # of Instrument, Sensor, etc. This guarantees a smooth time series for
     # each sensor
     rows <- nrow(dat_summarised)
-    dat_complete <- L2_complete(dat_summarised) # function is in L2-utils
+    dat_complete <- L2_complete(dat_summarised) # function is in L2_qaqc-utils
     message("\tCompleted data; started with ", rows, 
             " rows...now ", nrow(dat_summarised))
     


### PR DESCRIPTION
We use `tidy::complete` to add missing data, guaranteeing that every year's data file goes from 00:00:00 20xx-01-01 to 23:45:00 20xx-12-31:

https://github.com/COMPASS-DOE/sensor-data-pipeline/blob/fba4c3feebe1bf6b4ee0d8c4c077e0c439dd7652/pipeline/L2_qaqc-utils.R#L54-L57

However, the `fill` part of this step had incorrect column names. Surprisingly, this doesn't trigger an error, but it meant that `N_avg` and `N_drop` weren't being given zero values as intended.

Closes #358 
